### PR TITLE
feat: delete workshops

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ConfirmationModal } from "./ConfirmationModal";
+
+export default {
+  title: "ConfirmationModal",
+  component: ConfirmationModal,
+  argTypes: {
+    onConfirm: {
+      action: "confirmed",
+    },
+    onCancel: {
+      action: "cancelled",
+    },
+  },
+} as ComponentMeta<typeof ConfirmationModal>;
+
+const Template: ComponentStory<typeof ConfirmationModal> = (args) => (
+  <ConfirmationModal {...args} />
+);
+
+export const Main = Template.bind({});
+Main.storyName = "default";
+Main.args = {
+  open: true,
+  title: "Are you sure you want to delete it?",
+  cancelButtonLabel: "Cancel",
+  confirmButtonLabel: "Delete",
+};
+
+export const Loading = Template.bind({});
+Loading.storyName = "loading";
+Loading.args = {
+  open: true,
+  loading: true,
+  title: "Are you sure you want to delete it?",
+  cancelButtonLabel: "Cancel",
+  confirmButtonLabel: "Delete",
+};

--- a/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { noop, render } from "../../utils/testing";
+import { ConfirmationModal } from "./ConfirmationModal";
+
+const title = "Are you sure you want to delete it?";
+const confirmButtonLabel = "Delete";
+const cancelButtonLabel = "Cancel";
+
+describe("modal open", () => {
+  it("renders the modal", () => {
+    render(
+      <ConfirmationModal
+        title={title}
+        confirmButtonLabel={confirmButtonLabel}
+        cancelButtonLabel={cancelButtonLabel}
+        open={true}
+        loading={false}
+        onCancel={noop}
+        onConfirm={noop}
+      />
+    );
+    expect(document.body).toMatchSnapshot();
+  });
+});
+
+describe("modal close", () => {
+  it("renders not the modal", () => {
+    render(
+      <ConfirmationModal
+        title={title}
+        confirmButtonLabel={confirmButtonLabel}
+        cancelButtonLabel={cancelButtonLabel}
+        open={false}
+        loading={false}
+        onCancel={noop}
+        onConfirm={noop}
+      />
+    );
+    expect(document.body).toMatchSnapshot();
+  });
+});
+
+describe("loading", () => {
+  it("renders the modal w/ loading state", () => {
+    render(
+      <ConfirmationModal
+        title={title}
+        confirmButtonLabel={confirmButtonLabel}
+        cancelButtonLabel={cancelButtonLabel}
+        open={true}
+        loading={true}
+        onCancel={noop}
+        onConfirm={noop}
+      />
+    );
+    expect(document.body).toMatchSnapshot();
+  });
+});
+
+describe("click on confirm button", () => {
+  it("triggers the confirm listener", async () => {
+    const confirmHandler = jest.fn();
+
+    render(
+      <ConfirmationModal
+        title={title}
+        confirmButtonLabel={confirmButtonLabel}
+        cancelButtonLabel={cancelButtonLabel}
+        open={true}
+        loading={false}
+        onCancel={noop}
+        onConfirm={confirmHandler}
+      />
+    );
+
+    fireEvent.click(screen.getByText(confirmButtonLabel));
+
+    expect(confirmHandler).toHaveBeenCalled();
+  });
+});
+
+describe("click on cancel button", () => {
+  it("triggers the cancel listener", async () => {
+    const cancelHandler = jest.fn();
+
+    render(
+      <ConfirmationModal
+        title={title}
+        confirmButtonLabel={confirmButtonLabel}
+        cancelButtonLabel={cancelButtonLabel}
+        open={true}
+        loading={false}
+        onCancel={cancelHandler}
+        onConfirm={noop}
+      />
+    );
+
+    fireEvent.click(screen.getByText(cancelButtonLabel));
+
+    expect(cancelHandler).toHaveBeenCalled();
+  });
+});

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+
+export interface ConfirmationModalProps {
+  title: string;
+  cancelButtonLabel: string;
+  confirmButtonLabel: string;
+  open: boolean;
+  loading: boolean;
+  onCancel(): void;
+  onConfirm(): void;
+}
+
+export const ConfirmationModal: React.FunctionComponent<ConfirmationModalProps> =
+  ({
+    title,
+    cancelButtonLabel,
+    confirmButtonLabel,
+    open,
+    loading,
+    onCancel,
+    onConfirm,
+  }) => {
+    const theme = useTheme();
+    const fullScreen = useMediaQuery(theme.breakpoints.down("md"));
+
+    return (
+      <Dialog
+        open={open}
+        onClose={loading ? undefined : onCancel}
+        fullWidth
+        maxWidth="sm"
+        fullScreen={fullScreen}
+      >
+        <DialogTitle>{title}</DialogTitle>
+        <DialogActions sx={{ pr: 3, pl: 3, pb: 2 }}>
+          <Button
+            variant="outlined"
+            onClick={onCancel}
+            fullWidth={fullScreen}
+            disabled={loading}
+          >
+            {cancelButtonLabel}
+          </Button>
+          <LoadingButton
+            onClick={onConfirm}
+            variant="contained"
+            type="submit"
+            fullWidth={fullScreen}
+            loading={loading}
+          >
+            {confirmButtonLabel}
+          </LoadingButton>
+        </DialogActions>
+      </Dialog>
+    );
+  };

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -37,7 +37,7 @@ export const ConfirmationModal: React.FunctionComponent<ConfirmationModalProps> 
         open={open}
         onClose={loading ? undefined : onCancel}
         fullWidth
-        maxWidth="sm"
+        maxWidth="xs"
         fullScreen={fullScreen}
       >
         <DialogTitle>{title}</DialogTitle>

--- a/src/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
+++ b/src/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
@@ -1,0 +1,871 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loading renders the modal w/ loading state 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes animation-1 {
+  0% {
+    stroke-dasharray: 1px,200px;
+    stroke-dashoffset: 0;
+  }
+
+  50% {
+    stroke-dasharray: 100px,200px;
+    stroke-dashoffset: -15px;
+  }
+
+  100% {
+    stroke-dasharray: 100px,200px;
+    stroke-dashoffset: -125px;
+  }
+}
+
+.emotion-0 {
+  position: fixed;
+  z-index: 1300;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+}
+
+@media print {
+  .emotion-0 {
+    position: absolute!important;
+  }
+}
+
+.emotion-1 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  -webkit-tap-highlight-color: transparent;
+  z-index: -1;
+}
+
+.emotion-2 {
+  height: 100%;
+  outline: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media print {
+  .emotion-2 {
+    height: auto;
+  }
+}
+
+.emotion-3 {
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.87);
+  -webkit-transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  border-radius: 12px;
+  box-shadow: none;
+  margin: 32px;
+  position: relative;
+  overflow-y: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-height: calc(100% - 64px);
+  max-width: 600px;
+  width: calc(100% - 64px);
+}
+
+@media print {
+  .emotion-3 {
+    overflow-y: visible;
+    box-shadow: none;
+  }
+}
+
+@media (max-width:663.95px) {
+  .emotion-3.MuiDialog-paperScrollBody {
+    max-width: calc(100% - 64px);
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  font-family: "Source Sans Pro",sans-serif;
+  font-weight: 500;
+  font-size: 1.25rem;
+  line-height: 1.6;
+  padding: 16px 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 8px;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 24px;
+  padding-left: 24px;
+  padding-bottom: 16px;
+}
+
+.emotion-5>:not(:first-of-type) {
+  margin-left: 8px;
+}
+
+.emotion-6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Source Sans Pro",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 5px 15px;
+  border-radius: 12px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  border: 1px solid rgba(255, 59, 97, 0.5);
+  color: #ff3b61;
+}
+
+.emotion-6::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-6.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-6 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(255, 59, 97, 0.04);
+  border: 1px solid #ff3b61;
+}
+
+@media (hover: none) {
+  .emotion-6:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-6.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Source Sans Pro",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border-radius: 12px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #fff;
+  background-color: #ff3b61;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 0px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-7.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-7 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-7:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgb(178, 41, 67);
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
+}
+
+@media (hover: none) {
+  .emotion-7:hover {
+    background-color: #ff3b61;
+  }
+}
+
+.emotion-7:active {
+  box-shadow: none;
+}
+
+.emotion-7.Mui-focusVisible {
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 20px 25px -5px,rgba(0, 0, 0, 0.04) 0px 10px 10px -5px;
+}
+
+.emotion-7.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.emotion-7 .MuiLoadingButton-startIconLoadingStart,
+.emotion-7 .MuiLoadingButton-endIconLoadingEnd {
+  -webkit-transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  opacity: 0;
+}
+
+.emotion-7.MuiLoadingButton-loading {
+  color: transparent;
+}
+
+.emotion-8 {
+  position: absolute;
+  visibility: visible;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  left: 50%;
+  -webkit-transform: translate(-50%);
+  -moz-transform: translate(-50%);
+  -ms-transform: translate(-50%);
+  transform: translate(-50%);
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-9 {
+  display: inline-block;
+  -webkit-animation: animation-0 1.4s linear infinite;
+  animation: animation-0 1.4s linear infinite;
+}
+
+.emotion-10 {
+  display: block;
+}
+
+.emotion-11 {
+  stroke: currentColor;
+  stroke-dasharray: 80px,200px;
+  stroke-dashoffset: 0;
+  -webkit-animation: animation-1 1.4s ease-in-out infinite;
+  animation: animation-1 1.4s ease-in-out infinite;
+}
+
+<body
+  style="padding-right: 1024px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiModal-root MuiDialog-root emotion-0"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root emotion-1"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-test="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper emotion-2"
+      role="presentation"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":r3:"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth emotion-3"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root emotion-4"
+          id=":r3:"
+        >
+          Are you sure you want to delete it?
+        </h2>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing emotion-5"
+        >
+          <button
+            class="MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButtonBase-root Mui-disabled  emotion-6"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="MuiLoadingButton-root MuiLoadingButton-loading MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root Mui-disabled emotion-7"
+            disabled=""
+            id=":r4:"
+            tabindex="-1"
+            type="submit"
+          >
+            <div
+              class="MuiLoadingButton-loadingIndicator MuiLoadingButton-loadingIndicatorCenter emotion-8"
+            >
+              <span
+                aria-labelledby=":r4:"
+                class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorInherit emotion-9"
+                role="progressbar"
+                style="width: 16px; height: 16px;"
+              >
+                <svg
+                  class="MuiCircularProgress-svg emotion-10"
+                  viewBox="22 22 44 44"
+                >
+                  <circle
+                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-11"
+                    cx="44"
+                    cy="44"
+                    fill="none"
+                    r="20.2"
+                    stroke-width="3.6"
+                  />
+                </svg>
+              </span>
+            </div>
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-test="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`modal close renders not the modal 1`] = `
+<body
+  style=""
+>
+  <div />
+</body>
+`;
+
+exports[`modal open renders the modal 1`] = `
+.emotion-0 {
+  position: fixed;
+  z-index: 1300;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+}
+
+@media print {
+  .emotion-0 {
+    position: absolute!important;
+  }
+}
+
+.emotion-1 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  -webkit-tap-highlight-color: transparent;
+  z-index: -1;
+}
+
+.emotion-2 {
+  height: 100%;
+  outline: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media print {
+  .emotion-2 {
+    height: auto;
+  }
+}
+
+.emotion-3 {
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.87);
+  -webkit-transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  border-radius: 12px;
+  box-shadow: none;
+  margin: 32px;
+  position: relative;
+  overflow-y: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-height: calc(100% - 64px);
+  max-width: 600px;
+  width: calc(100% - 64px);
+}
+
+@media print {
+  .emotion-3 {
+    overflow-y: visible;
+    box-shadow: none;
+  }
+}
+
+@media (max-width:663.95px) {
+  .emotion-3.MuiDialog-paperScrollBody {
+    max-width: calc(100% - 64px);
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  font-family: "Source Sans Pro",sans-serif;
+  font-weight: 500;
+  font-size: 1.25rem;
+  line-height: 1.6;
+  padding: 16px 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 8px;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-right: 24px;
+  padding-left: 24px;
+  padding-bottom: 16px;
+}
+
+.emotion-5>:not(:first-of-type) {
+  margin-left: 8px;
+}
+
+.emotion-6 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Source Sans Pro",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 5px 15px;
+  border-radius: 12px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  border: 1px solid rgba(255, 59, 97, 0.5);
+  color: #ff3b61;
+}
+
+.emotion-6::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-6.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-6 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-6:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(255, 59, 97, 0.04);
+  border: 1px solid #ff3b61;
+}
+
+@media (hover: none) {
+  .emotion-6:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-6.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Source Sans Pro",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border-radius: 12px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #fff;
+  background-color: #ff3b61;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 0px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-7.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-7 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-7:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgb(178, 41, 67);
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
+}
+
+@media (hover: none) {
+  .emotion-7:hover {
+    background-color: #ff3b61;
+  }
+}
+
+.emotion-7:active {
+  box-shadow: none;
+}
+
+.emotion-7.Mui-focusVisible {
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 20px 25px -5px,rgba(0, 0, 0, 0.04) 0px 10px 10px -5px;
+}
+
+.emotion-7.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+.emotion-7 .MuiLoadingButton-startIconLoadingStart,
+.emotion-7 .MuiLoadingButton-endIconLoadingEnd {
+  -webkit-transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  opacity: 0;
+}
+
+.emotion-7.MuiLoadingButton-loading {
+  color: transparent;
+}
+
+<body
+  style="padding-right: 1024px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiModal-root MuiDialog-root emotion-0"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root emotion-1"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-test="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper emotion-2"
+      role="presentation"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":r0:"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth emotion-3"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root emotion-4"
+          id=":r0:"
+        >
+          Are you sure you want to delete it?
+        </h2>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing emotion-5"
+        >
+          <button
+            class="MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButtonBase-root  emotion-6"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="MuiLoadingButton-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root emotion-7"
+            id=":r1:"
+            tabindex="0"
+            type="submit"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-test="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/src/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
+++ b/src/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`loading renders the modal w/ loading state 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: calc(100% - 64px);
-  max-width: 600px;
+  max-width: 444px;
   width: calc(100% - 64px);
 }
 
@@ -124,7 +124,7 @@ exports[`loading renders the modal w/ loading state 1`] = `
   }
 }
 
-@media (max-width:663.95px) {
+@media (max-width:507.95px) {
   .emotion-3.MuiDialog-paperScrollBody {
     max-width: calc(100% - 64px);
   }
@@ -413,7 +413,7 @@ exports[`loading renders the modal w/ loading state 1`] = `
     >
       <div
         aria-labelledby=":r3:"
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth emotion-3"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthXs MuiDialog-paperFullWidth emotion-3"
         role="dialog"
       >
         <h2
@@ -565,7 +565,7 @@ exports[`modal open renders the modal 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: calc(100% - 64px);
-  max-width: 600px;
+  max-width: 444px;
   width: calc(100% - 64px);
 }
 
@@ -576,7 +576,7 @@ exports[`modal open renders the modal 1`] = `
   }
 }
 
-@media (max-width:663.95px) {
+@media (max-width:507.95px) {
   .emotion-3.MuiDialog-paperScrollBody {
     max-width: calc(100% - 64px);
   }
@@ -832,7 +832,7 @@ exports[`modal open renders the modal 1`] = `
     >
       <div
         aria-labelledby=":r0:"
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth emotion-3"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthXs MuiDialog-paperFullWidth emotion-3"
         role="dialog"
       >
         <h2

--- a/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.graphql
+++ b/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.graphql
@@ -1,0 +1,5 @@
+mutation DeleteWorkshop($workshopId: ID!) {
+  deleteWorkshop(workshopId: $workshopId) {
+    ok
+  }
+}

--- a/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.translations.ts
+++ b/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.translations.ts
@@ -1,0 +1,3 @@
+export const title = "Are you sure you want to delete the workshop?";
+export const confirmButtonLabel = "Delete";
+export const cancelButtonLabel = "Cancel";

--- a/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.tsx
+++ b/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { ConfirmationModal } from "../../components/ConfirmationModal/ConfirmationModal";
+import * as translations from "./DeleteWorkshopModalContainer.translations";
+
+export interface DeleteWorkshopModalContainerProps {
+  onClose(): void;
+  workshopId: string;
+}
+
+export const DeleteWorkshopModalContainer: React.FunctionComponent<DeleteWorkshopModalContainerProps> =
+  ({ workshopId, onClose }) => {
+    const handleCancel = () => {
+      onClose();
+    };
+
+    const handleDeletion = async () => {
+      onClose();
+    };
+
+    return (
+      <ConfirmationModal
+        open={true}
+        loading={false}
+        title={translations.title}
+        confirmButtonLabel={translations.confirmButtonLabel}
+        cancelButtonLabel={translations.cancelButtonLabel}
+        onCancel={handleCancel}
+        onConfirm={handleDeletion}
+      />
+    );
+  };

--- a/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.tsx
+++ b/src/containers/DeleteWorkshopModalContainer/DeleteWorkshopModalContainer.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { ConfirmationModal } from "../../components/ConfirmationModal/ConfirmationModal";
+import { useDeleteWorkshopMutation } from "./DeleteWorkshopModalContainer.generated";
+import { WorkshopListDocument } from "../WorkshopListContainer/WorkshopListContainer.generated";
 import * as translations from "./DeleteWorkshopModalContainer.translations";
 
 export interface DeleteWorkshopModalContainerProps {
@@ -9,18 +11,29 @@ export interface DeleteWorkshopModalContainerProps {
 
 export const DeleteWorkshopModalContainer: React.FunctionComponent<DeleteWorkshopModalContainerProps> =
   ({ workshopId, onClose }) => {
+    const [deleteWorkshopMutation, mutationOptions] =
+      useDeleteWorkshopMutation();
+
     const handleCancel = () => {
       onClose();
     };
 
     const handleDeletion = async () => {
+      await deleteWorkshopMutation({
+        variables: {
+          workshopId,
+        },
+        refetchQueries: [WorkshopListDocument],
+        awaitRefetchQueries: true,
+      });
+
       onClose();
     };
 
     return (
       <ConfirmationModal
         open={true}
-        loading={false}
+        loading={mutationOptions.loading}
         title={translations.title}
         confirmButtonLabel={translations.confirmButtonLabel}
         cancelButtonLabel={translations.cancelButtonLabel}

--- a/src/containers/WorkshopMenuContainer/WorkshopMenuContainer.translations.ts
+++ b/src/containers/WorkshopMenuContainer/WorkshopMenuContainer.translations.ts
@@ -1,1 +1,2 @@
 export const menuItemEdit = "Edit";
+export const menuItemDelete = "Delete";

--- a/src/containers/WorkshopMenuContainer/WorkshopMenuContainer.tsx
+++ b/src/containers/WorkshopMenuContainer/WorkshopMenuContainer.tsx
@@ -5,6 +5,7 @@ import { UserRole } from "../../types";
 import { UpdateWorkshopModalContainer } from "../UpdateWorkshopModalContainer/UpdateWorkshopModalContainer";
 import { MenuItem } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
 import * as translations from "./WorkshopMenuContainer.translations";
 
 export interface WorkshopMenuContainerProps {
@@ -17,7 +18,8 @@ export interface WorkshopMenuContainerProps {
 
 export const WorkshopMenuContainer: React.FunctionComponent<WorkshopMenuContainerProps> =
   ({ description, title, awsAccountId, attendees, workshopId }) => {
-    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const { role } = useContext(UserContext);
 
     if (role !== UserRole.Admin) {
@@ -27,14 +29,18 @@ export const WorkshopMenuContainer: React.FunctionComponent<WorkshopMenuContaine
     return (
       <>
         <WorkshopMenu id={workshopId}>
-          <MenuItem onClick={() => setIsModalOpen(true)}>
+          <MenuItem onClick={() => setIsUpdateModalOpen(true)}>
             <EditIcon />
             {translations.menuItemEdit}
           </MenuItem>
+          <MenuItem onClick={() => setIsDeleteModalOpen(true)}>
+            <DeleteIcon />
+            {translations.menuItemDelete}
+          </MenuItem>
         </WorkshopMenu>
-        {isModalOpen && (
+        {isUpdateModalOpen && (
           <UpdateWorkshopModalContainer
-            onClose={() => setIsModalOpen(false)}
+            onClose={() => setIsUpdateModalOpen(false)}
             workshopId={workshopId}
             title={title}
             description={description}

--- a/src/containers/WorkshopMenuContainer/WorkshopMenuContainer.tsx
+++ b/src/containers/WorkshopMenuContainer/WorkshopMenuContainer.tsx
@@ -6,6 +6,7 @@ import { UpdateWorkshopModalContainer } from "../UpdateWorkshopModalContainer/Up
 import { MenuItem } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
+import { DeleteWorkshopModalContainer } from "../DeleteWorkshopModalContainer/DeleteWorkshopModalContainer";
 import * as translations from "./WorkshopMenuContainer.translations";
 
 export interface WorkshopMenuContainerProps {
@@ -46,6 +47,12 @@ export const WorkshopMenuContainer: React.FunctionComponent<WorkshopMenuContaine
             description={description}
             awsAccountId={awsAccountId}
             attendees={attendees}
+          />
+        )}
+        {isDeleteModalOpen && (
+          <DeleteWorkshopModalContainer
+            onClose={() => setIsDeleteModalOpen(false)}
+            workshopId={workshopId}
           />
         )}
       </>


### PR DESCRIPTION
## Technical details

We extended the context menu and added a new menu item. The user can click on the menu item to delete a workshop. After clicking, the system opens a modal to confirm the deletion. 

![image](https://user-images.githubusercontent.com/8983106/189346716-3efcb478-db7f-4085-a044-dfa51f106277.png)

![image](https://user-images.githubusercontent.com/8983106/189346757-3c1daf4a-d316-4eb4-9607-262e77ff3cce.png)

## Tasks
- [x] New modal to confirm actions
- [x] New list item in the workshop menu
- [x] Container for the confirmation modal to delete workshops 

Paired with @skomp 😎